### PR TITLE
fix to compile ink contract

### DIFF
--- a/contracts/std_ref/Cargo.toml
+++ b/contracts/std_ref/Cargo.toml
@@ -25,3 +25,6 @@ std = [
 ]
 ink-as-dependency = []
 e2e-tests = []
+
+[profile.release]
+overflow-checks = false

--- a/contracts/std_ref/lib.rs
+++ b/contracts/std_ref/lib.rs
@@ -6,6 +6,7 @@ mod reference_data;
 #[ink::contract]
 mod std_ref {
     use ink::env::set_code_hash;
+    use ink::prelude::vec::Vec;
     use ink::storage::Mapping;
 
     use crate::constant::{E9, USD};
@@ -171,7 +172,8 @@ mod std_ref {
         }
 
         /// Returns the reference data for a given symbol
-        pub fn get_reference_data(&mut self, symbol_pair: &(Hash, Hash)) -> Result<ReferenceData> {
+        #[ink(message)]
+        pub fn get_reference_data(&mut self, symbol_pair: (Hash, Hash)) -> Result<ReferenceData> {
             let base = self.get_ref_data(symbol_pair.0)?;
             let quote = self.get_ref_data(symbol_pair.1)?;
 
@@ -179,12 +181,13 @@ mod std_ref {
         }
 
         /// Returns
+        #[ink(message)]
         pub fn get_reference_data_bulk(
             &mut self,
-            symbol_pair: &Vec<(Hash, Hash)>,
+            symbol_pair: Vec<(Hash, Hash)>,
         ) -> Vec<Result<ReferenceData>> {
             symbol_pair
-                .iter()
+                .into_iter()
                 .map(|pair| self.get_reference_data(pair))
                 .collect()
         }
@@ -266,7 +269,7 @@ mod std_ref {
                 .iter()
                 .map(|(s, _)| (*s, Hash::from(USD)))
                 .collect();
-            let rd = std_ref.get_reference_data_bulk(&symbol_pairs);
+            let rd = std_ref.get_reference_data_bulk(symbol_pairs);
 
             for ((_, o), r) in symbol_rates.iter().zip(rd) {
                 assert_eq!((o * E9) as u128, r.unwrap().rate);
@@ -301,7 +304,7 @@ mod std_ref {
                 .iter()
                 .map(|(s, _)| (*s, Hash::from(USD)))
                 .collect();
-            let rd = std_ref.get_reference_data_bulk(&symbol_pairs);
+            let rd = std_ref.get_reference_data_bulk(symbol_pairs);
 
             for ((_, o), r) in symbol_rates.iter().zip(rd) {
                 assert_eq!((o * E9) as u128, r.unwrap().rate);
@@ -336,7 +339,7 @@ mod std_ref {
                 .iter()
                 .map(|(s, _)| (*s, Hash::from(USD)))
                 .collect();
-            let rd = std_ref.get_reference_data_bulk(&symbol_pairs);
+            let rd = std_ref.get_reference_data_bulk(symbol_pairs);
 
             for ((_, o), r) in symbol_rates.iter().zip(rd) {
                 assert_eq!((o * E9) as u128, r.unwrap().rate);

--- a/contracts/std_ref/ref_data.rs
+++ b/contracts/std_ref/ref_data.rs
@@ -1,9 +1,11 @@
-use ink::storage::traits::{StorageLayout};
-use scale::{Encode, Decode};
-use scale_info::TypeInfo;
+use scale::{Decode, Encode};
 
-#[derive(StorageLayout, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(TypeInfo))]
+#[derive(Encode, Decode)]
+#[cfg_attr(
+    feature = "std",
+    derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout)
+)]
+
 pub struct RefDatum {
     pub rate: u64,
     pub resolve_time: u64,


### PR DESCRIPTION
**Implementation Details**
- Fix the code to pass Ink contract compiler
- Deploy code to Shibuya
- Test relay and get reference data

**Example:**
This example provided FTM/BUSD price
contract: [here](https://shibuya.subscan.io/wasm_contract/Yjj2DQA4AznhucyvoYVyNXLqZu6KVDKuC3xvjt7oVF5ucZ1?tab=transaction)
<img width="1629" alt="Screenshot 2566-12-20 at 14 22 08" src="https://github.com/bandprotocol/band-std-reference-contracts-ink/assets/32817745/636e80c3-397e-47c4-b55f-7181e4103036">